### PR TITLE
Update array-union dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "array-differ": "^0.1.0",
-    "array-union": "^0.1.0",
+    "array-union": "^1.0.0",
     "minimatch": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes errors when run with the --harmony flag

You can see the difference by running mocha with the --harmony flag, before and after.
