### PR TITLE
allow functions and regexps in patterns array

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,13 +18,25 @@ module.exports = function (list, patterns, options) {
 	options = options || {};
 
 	return patterns.reduce(function (ret, pattern) {
-		var process = union;
+		if (typeof pattern === 'function') {
 
-		if (pattern[0] === '!') {
-			pattern = pattern.slice(1);
-			process = diff;
+			return union(ret, list.filter(pattern));
+
+		} else if (pattern instanceof RegExp) {
+
+			return union(ret, list.filter(function(item) {
+				return pattern.test(item);
+			}));
+
+		} else {
+			var process = union;
+
+			if (pattern[0] === '!') {
+				pattern = pattern.slice(1);
+				process = diff;
+			}
+
+			return process(ret, minimatch.match(list, pattern, options));
 		}
-
-		return process(ret, minimatch.match(list, pattern, options));
 	}, []);
 };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 'use strict';
 var expect = require('chai').expect;
+var path = require('path');
 var mm = require('./');
 
 describe('when an array of additive glob patterns is defined:', function () {
@@ -169,6 +170,28 @@ describe('globule', function () {
 		expect(mm('foo.js', ['*.js', '*.css'])).to.eql(['foo.js']);
 		expect(mm(['foo.js'], ['*.js', '*.css'])).to.eql(['foo.js']);
 		expect(mm(['foo.js', 'bar.css'], ['*.js', '*.css'])).to.eql(['foo.js', 'bar.css']);
+	});
+
+	it('function matching should match correctly', function () {
+		var js = function(item) { return path.extname(item) === '.js'; };
+		var css = function(item) { return path.extname(item) === '.css'; };
+		expect(mm('foo.js', js)).to.eql(['foo.js']);
+		expect(mm(['foo.js'], js)).to.eql(['foo.js']);
+		expect(mm(['foo.js', 'bar.css'], js)).to.eql(['foo.js']);
+		expect(mm('foo.js', [js, css])).to.eql(['foo.js']);
+		expect(mm(['foo.js'], [js, css])).to.eql(['foo.js']);
+		expect(mm(['foo.js', 'bar.css'], [js, css])).to.eql(['foo.js', 'bar.css']);
+	});
+
+	it('regexp matching should match correctly', function () {
+		var js = /.*\.js$/;
+		var css = /.*\.css$/;
+		expect(mm('foo.js', js)).to.eql(['foo.js']);
+		expect(mm(['foo.js'], js)).to.eql(['foo.js']);
+		expect(mm(['foo.js', 'bar.css'], js)).to.eql(['foo.js']);
+		expect(mm('foo.js', [js, css])).to.eql(['foo.js']);
+		expect(mm(['foo.js'], [js, css])).to.eql(['foo.js']);
+		expect(mm(['foo.js', 'bar.css'], [js, css])).to.eql(['foo.js', 'bar.css']);
 	});
 
 	describe('no matches:', function () {


### PR DESCRIPTION
How about allowing filter functions and regular expressions in the `patterns` array?

No worries if you feel this complicates things too much.